### PR TITLE
feat: 🚀 - [Report] - Get scrapping result detail of keyword

### DIFF
--- a/src/components/HistoryTable/HistoryTable.tsx
+++ b/src/components/HistoryTable/HistoryTable.tsx
@@ -13,6 +13,7 @@ import Button from "@mui/material/Button";
 import ReplayIcon from "@mui/icons-material/Replay";
 import { KeywordStatus, keywordStatusColor } from "@enums/keyword.enum";
 import Typography from "@mui/material/Typography";
+import KeywordDetailModal from "@components/KeywordDetailModal/KeywordDetailModal";
 
 const columns: GridColDef[] = [
   {
@@ -71,6 +72,8 @@ export default function HistoryTable() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [totalRows, setTotalRows] = useState<number>(0);
   const [searchTerm, setSearchTerm] = useState<string>("");
+  const [isOpenDetailModal, setOpenDetailModal] = useState<boolean>(false);
+  const [selectedKeywordId, setSelectedKeywordId] = useState<number>();
 
   const fetchKeywords = useCallback(
     async (paginateReq?: Pagination, filter?: Filter) => {
@@ -131,6 +134,21 @@ export default function HistoryTable() {
     fetchKeywords(pagination, { search: searchTerm });
   }, 400);
 
+  const handleRowClick = ({ row }: { row: Keyword }) => {
+    if (row.status !== KeywordStatus.Completed) {
+      toast.warning("Keyword processing not completed");
+      return;
+    }
+
+    setOpenDetailModal(true);
+    setSelectedKeywordId(row.id);
+  };
+
+  const handleCloseModal = () => {
+    setOpenDetailModal(false);
+    setSelectedKeywordId(null);
+  };
+
   return (
     <Stack className="flex flex-col h-[80vh] w-full">
       <Box className="flex flex-row gap-2">
@@ -160,6 +178,7 @@ export default function HistoryTable() {
         loading={isLoading}
         paginationModel={pagination}
         onPaginationModelChange={handlePaginationChanged}
+        onRowClick={handleRowClick}
         className="mt-3"
         sx={{
           ".MuiDataGrid-overlayWrapperInner": {
@@ -177,6 +196,12 @@ export default function HistoryTable() {
             cursor: "default",
           },
         }}
+      />
+
+      <KeywordDetailModal
+        isOpen={isOpenDetailModal}
+        keywordId={selectedKeywordId}
+        handleClose={handleCloseModal}
       />
     </Stack>
   );

--- a/src/components/KeywordDetailModal/KeywordDetailModal.tsx
+++ b/src/components/KeywordDetailModal/KeywordDetailModal.tsx
@@ -1,0 +1,215 @@
+import React, { useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Modal from "@mui/material/Modal";
+import Stack from "@mui/material/Stack";
+import CodeIcon from "@mui/icons-material/Code";
+import CircularProgress from "@mui/material/CircularProgress";
+import Button from "@mui/material/Button";
+import CloseIcon from "@mui/icons-material/Close";
+import { ReportKeyword } from "@interfaces/report.interface";
+import { useAuth } from "@contexts/useAuthContext";
+import KeyIcon from "@mui/icons-material/Key";
+import NewspaperIcon from "@mui/icons-material/Newspaper";
+import LinkIcon from "@mui/icons-material/Link";
+import { toast } from "react-toastify";
+import api from "@config/axios-request";
+
+interface ReportItemProps {
+  icon: React.ElementType;
+  value: string | number;
+  label: string;
+  preview?: boolean;
+}
+
+const ReportItem = ({ icon: Icon, value, label, preview }: ReportItemProps) => {
+  const handleOpenHtmlPage = () => {
+    const blob = new Blob(["\ufeff", value as string], {
+      type: "text/html;charset=utf-8",
+    });
+
+    const blobUrl = URL.createObjectURL(blob);
+
+    window.open(blobUrl, "_blank");
+
+    return () => URL.revokeObjectURL(blobUrl);
+  };
+
+  return (
+    <Stack
+      direction="row"
+      spacing={4}
+      sx={{
+        flex: 1,
+        p: 2,
+        boxShadow:
+          "rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Icon fontSize="large" sx={{ color: "orange" }} />
+      </Box>
+      <Stack
+        direction="column"
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        {preview ? (
+          <Button
+            onClick={handleOpenHtmlPage}
+            sx={{
+              textTransform: "none",
+              color: "orange",
+              fontWeight: "bold",
+              textAlign: "left",
+            }}
+          >
+            Preview HTML page cache
+          </Button>
+        ) : (
+          <Typography variant="h6" fontWeight="bold">
+            {value}
+          </Typography>
+        )}
+
+        {!preview && <Typography sx={{ color: "gray" }}>{label}</Typography>}
+      </Stack>
+    </Stack>
+  );
+};
+
+interface KeywordDetailModalProps {
+  isOpen: boolean;
+  keywordId: number;
+  handleClose: () => void;
+}
+
+export default function KeywordDetailModal({
+  isOpen,
+  keywordId,
+  handleClose,
+}: KeywordDetailModalProps) {
+  const { accessToken } = useAuth();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [reportKeyword, setReportKeyword] = useState<ReportKeyword>(null);
+
+  useEffect(() => {
+    const fetchReportKeyword = async () => {
+      setIsLoading(true);
+      try {
+        const response = await api.get<ReportKeyword>(
+          `/report/${keywordId}/detail`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+
+        if (response?.data) {
+          setReportKeyword(response.data);
+        }
+      } catch (error) {
+        toast.error(error?.response?.data?.message || "Something went wrong!");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (keywordId) {
+      fetchReportKeyword();
+    }
+  }, [accessToken, keywordId]);
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          overflow: "auto",
+          bgcolor: "background.paper",
+          boxShadow: 24,
+          px: 10,
+          py: 5,
+        }}
+      >
+        {isLoading ? (
+          <Box
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+            }}
+          >
+            <CircularProgress sx={{ color: "orange" }} />
+          </Box>
+        ) : (
+          <Box>
+            <Box
+              sx={{
+                position: "absolute",
+                top: 25,
+                right: 20,
+                cursor: "pointer",
+              }}
+              onClick={handleClose}
+            >
+              <CloseIcon fontSize="large" />
+            </Box>
+            <Typography variant="h5" sx={{ color: "orange" }}>
+              Keyword overview
+            </Typography>
+            <Box
+              sx={{
+                mt: 4,
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "space-between",
+                gap: 2,
+              }}
+            >
+              <ReportItem
+                icon={KeyIcon}
+                value={reportKeyword?.keyword}
+                label="Keyword"
+              />
+              <ReportItem
+                icon={NewspaperIcon}
+                value={reportKeyword?.totalAds}
+                label="Total advertisements"
+              />
+              <ReportItem
+                icon={LinkIcon}
+                value={reportKeyword?.totalLinks}
+                label="Total links"
+              />
+              <ReportItem
+                icon={CodeIcon}
+                value={reportKeyword?.htmlCachePage}
+                preview
+                label="Preview page cache"
+              />
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Modal>
+  );
+}

--- a/src/interfaces/report.interface.ts
+++ b/src/interfaces/report.interface.ts
@@ -1,0 +1,9 @@
+export interface ReportKeyword {
+  keywordId: number;
+  keyword: string;
+  totalAds: number;
+  totalLinks: number;
+  htmlCachePage: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}


### PR DESCRIPTION
## 📚 Changes being made

- Create `KeywordDetailModal` to open modal and show detail search result of keyword
- Allow view keyword detail in bot upload page and history page
- Allow user view HTML page of google search keyword by open new page by button

## ⚖️ What's the context?

- We need a place to show detail report of scrapped keyword

## 📸 UI preview
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/183e9ee2-80bc-4989-ad93-d982f85e57c8" />
<img width="862" alt="image" src="https://github.com/user-attachments/assets/20a51a53-3799-491f-8791-e8d94e843575" />

## 🧪 Unit tests

**👎 No, to implement unit test later**
- `KeywordDetailModal` component
- Others legacy components